### PR TITLE
修改后台答题记录成绩显示始终为100的问题🤗

### DIFF
--- a/app/api/ctf/views.py
+++ b/app/api/ctf/views.py
@@ -167,7 +167,7 @@ def answers_list():
                 "type": question.type,
                 "name": question.name
             },
-            "score": 100,
+            "score": answer.score,
             "flag": answer.flag,
             "username": user.username,
             "ip": answer.ip


### PR DESCRIPTION
后台答题记录那里的分数，始终显示为100，看了一下是源码里面写死了100，我给改过来了

![1648450415552.png](https://img.ukx.cn/abcdocker/2022/03/28/7a7c5fb4ccfc0/7a7c5fb4ccfc0.png)